### PR TITLE
Removed unused 'drupal/autologout' dev dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,6 @@
     "require": {
         "php": ">=8.2"
     },
-    "require-dev": {
-        "drupal/autologout": "^2"
-    },
     "suggest": {
         "drupal/search_api": "^1.25"
     }


### PR DESCRIPTION
## Summary

Removed `drupal/autologout` from `require-dev` in `composer.json`. The package is not referenced anywhere in the codebase — no tests, configuration, or code use it.

## Changes

- Removed `"drupal/autologout": "^2"` from `require-dev` section in `composer.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Removed unused 'drupal/autologout' dev dependency

Removed `drupal/autologout` (version `^2`) from the `require-dev` section of `composer.json`. The package is not referenced anywhere in the codebase and is not used in tests, configuration, or code.

**Changes:**
- `composer.json`: Deleted `drupal/autologout` from `require-dev`

**Impact:**
- Low: Development dependency removal with no direct impact on functionality
- Reduces project bloat and maintenance burden by removing unused development dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->