### PR TITLE
[#46] Fixed Testmode ignoring config overrides from settings.php.

### DIFF
--- a/src/Testmode.php
+++ b/src/Testmode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\testmode;
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\State\StateInterface;
 
@@ -33,11 +32,11 @@ class Testmode {
   protected static ?Testmode $instance = NULL;
 
   /**
-   * Drupal config instance.
+   * Drupal config factory.
    *
-   * @var \Drupal\Core\Config\Config
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  protected Config $config;
+  protected ConfigFactoryInterface $configFactory;
 
   /**
    * Drupal state instance.
@@ -50,7 +49,7 @@ class Testmode {
    * Testmode constructor.
    */
   public function __construct(ConfigFactoryInterface $configFactory, StateInterface $state) {
-    $this->config = $configFactory->getEditable('testmode.settings');
+    $this->configFactory = $configFactory;
     $this->state = $state;
   }
 
@@ -154,7 +153,7 @@ class Testmode {
    *   Array of node views machine names.
    */
   public function getNodeViews(): array {
-    $value = $this->config->get('views_node');
+    $value = $this->configFactory->get('testmode.settings')->get('views_node');
     return is_array($value) ? $value : [];
   }
 
@@ -168,7 +167,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setNodeViews(array|string $value): Testmode {
-    $this->config->set('views_node', self::multilineToArray($value))->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('views_node', self::multilineToArray($value))
+      ->save();
     return $this;
   }
 
@@ -179,7 +180,7 @@ class Testmode {
    *   Array of term views machine names.
    */
   public function getTermViews(): array {
-    $value = $this->config->get('views_term');
+    $value = $this->configFactory->get('testmode.settings')->get('views_term');
     return is_array($value) ? $value : [];
   }
 
@@ -193,7 +194,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setTermViews(array|string $value): Testmode {
-    $this->config->set('views_term', self::multilineToArray($value))->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('views_term', self::multilineToArray($value))
+      ->save();
     return $this;
   }
 
@@ -204,7 +207,7 @@ class Testmode {
    *   TRUE if the flag is set, FALSE otherwise.
    */
   public function getListTerm(): bool {
-    return (bool) $this->config->get('list_term');
+    return (bool) $this->configFactory->get('testmode.settings')->get('list_term');
   }
 
   /**
@@ -217,7 +220,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setTermsList(bool $value): Testmode {
-    $this->config->set('list_term', $value)->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('list_term', $value)
+      ->save();
     return $this;
   }
 
@@ -228,7 +233,7 @@ class Testmode {
    *   Array of user views machine names.
    */
   public function getUserViews(): array {
-    $value = $this->config->get('views_user');
+    $value = $this->configFactory->get('testmode.settings')->get('views_user');
     return is_array($value) ? $value : [];
   }
 
@@ -242,7 +247,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setUserViews(array|string $value): Testmode {
-    $this->config->set('views_user', self::multilineToArray($value))->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('views_user', self::multilineToArray($value))
+      ->save();
     return $this;
   }
 
@@ -253,7 +260,7 @@ class Testmode {
    *   Array of node patterns.
    */
   public function getNodePatterns(): array {
-    $value = $this->config->get('pattern_node');
+    $value = $this->configFactory->get('testmode.settings')->get('pattern_node');
     return is_array($value) ? $value : [];
   }
 
@@ -267,7 +274,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setNodePatterns(array|string $value): Testmode {
-    $this->config->set('pattern_node', self::multilineToArray($value))->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('pattern_node', self::multilineToArray($value))
+      ->save();
     return $this;
   }
 
@@ -278,7 +287,7 @@ class Testmode {
    *   Array of term patterns.
    */
   public function getTermPatterns(): array {
-    $value = $this->config->get('pattern_term');
+    $value = $this->configFactory->get('testmode.settings')->get('pattern_term');
     return is_array($value) ? $value : [];
   }
 
@@ -292,7 +301,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setTermPatterns(array|string $value): Testmode {
-    $this->config->set('pattern_term', self::multilineToArray($value))->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('pattern_term', self::multilineToArray($value))
+      ->save();
     return $this;
   }
 
@@ -303,7 +314,7 @@ class Testmode {
    *   Array of user patterns.
    */
   public function getUserPatterns(): array {
-    $value = $this->config->get('pattern_user');
+    $value = $this->configFactory->get('testmode.settings')->get('pattern_user');
     return is_array($value) ? $value : [];
   }
 
@@ -317,7 +328,9 @@ class Testmode {
    *   Current class instance.
    */
   public function setUserPatterns(array|string $value): Testmode {
-    $this->config->set('pattern_user', self::multilineToArray($value))->save();
+    $this->configFactory->getEditable('testmode.settings')
+      ->set('pattern_user', self::multilineToArray($value))
+      ->save();
     return $this;
   }
 

--- a/tests/src/Kernel/TestmodeConfigOverrideTest.php
+++ b/tests/src/Kernel/TestmodeConfigOverrideTest.php
@@ -38,6 +38,19 @@ class TestmodeConfigOverrideTest extends KernelTestBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    // Remove any $config override installed by a test so the global state
+    // does not leak into other kernel tests sharing the same PHP process.
+    unset($GLOBALS['config']['testmode.settings']);
+    if (\Drupal::hasContainer()) {
+      \Drupal::configFactory()->reset('testmode.settings');
+    }
+    parent::tearDown();
+  }
+
+  /**
    * Tests that a getter reflects $config[...] overrides.
    *
    * @param string $setter

--- a/tests/src/Kernel/TestmodeConfigOverrideTest.php
+++ b/tests/src/Kernel/TestmodeConfigOverrideTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\testmode\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\testmode\Testmode;
+
+/**
+ * Tests that Testmode respects $config[...] overrides from settings.php.
+ *
+ * See https://github.com/AlexSkrypnyk/testmode/issues/46.
+ *
+ * @group Testmode
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+class TestmodeConfigOverrideTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['testmode'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['testmode']);
+    // Reset the Testmode singleton so each test gets a fresh instance that
+    // picks up the current container's config factory.
+    $reflection = new \ReflectionClass(Testmode::class);
+    $instance = $reflection->getProperty('instance');
+    $instance->setAccessible(TRUE);
+    $instance->setValue(NULL, NULL);
+  }
+
+  /**
+   * Tests that a getter reflects $config[...] overrides.
+   *
+   * @param string $setter
+   *   Setter method name on Testmode to write the stored value.
+   * @param string $getter
+   *   Getter method name on Testmode to read the effective value.
+   * @param string $config_key
+   *   The key under 'testmode.settings' that backs the getter.
+   * @param mixed $stored_value
+   *   Value written via the setter (becomes the raw stored value).
+   * @param mixed $override_value
+   *   Value installed as the $GLOBALS['config'] override.
+   * @param mixed $expected
+   *   Value expected to be returned by the getter once the override is set.
+   *
+   * @dataProvider dataProviderOverrides
+   */
+  public function testGetterReflectsOverride(string $setter, string $getter, string $config_key, mixed $stored_value, mixed $override_value, mixed $expected): void {
+    $testmode = Testmode::getInstance();
+    $testmode->{$setter}($stored_value);
+
+    // Sanity check: without an override the getter reflects the stored value.
+    $this->assertSame($stored_value, $testmode->{$getter}(), sprintf('Stored value is returned by %s() before the override is installed.', $getter));
+
+    $GLOBALS['config']['testmode.settings'][$config_key] = $override_value;
+    // Reset the config factory cache so the override is picked up.
+    \Drupal::configFactory()->reset('testmode.settings');
+
+    $this->assertSame($expected, $testmode->{$getter}(), sprintf('%s() returns the overridden value once $config[testmode.settings][%s] is set.', $getter, $config_key));
+  }
+
+  /**
+   * Data provider for testGetterReflectsOverride().
+   *
+   * @return array<string, array<int, mixed>>
+   *   Test cases.
+   */
+  public static function dataProviderOverrides(): array {
+    return [
+      'views_node' => ['setNodeViews', 'getNodeViews', 'views_node', ['content'], ['content', 'my_view'], ['content', 'my_view']],
+      'views_term' => ['setTermViews', 'getTermViews', 'views_term', ['term_view'], ['term_view', 'other_term_view'], ['term_view', 'other_term_view']],
+      'views_user' => ['setUserViews', 'getUserViews', 'views_user', ['user_admin_people'], ['user_admin_people', 'extra_user_view'], ['user_admin_people', 'extra_user_view']],
+      'pattern_node' => ['setNodePatterns', 'getNodePatterns', 'pattern_node', ['[TEST%'], ['[QATEST%'], ['[QATEST%']],
+      'pattern_term' => ['setTermPatterns', 'getTermPatterns', 'pattern_term', ['[TEST%'], ['[QATEST%'], ['[QATEST%']],
+      'pattern_user' => ['setUserPatterns', 'getUserPatterns', 'pattern_user', ['%example%'], ['%qa%'], ['%qa%']],
+    ];
+  }
+
+  /**
+   * Tests that getListTerm() reflects $config[...] overrides.
+   */
+  public function testGetListTermReflectsOverride(): void {
+    $testmode = Testmode::getInstance();
+    $testmode->setTermsList(TRUE);
+    $this->assertTrue($testmode->getListTerm(), 'Stored value is returned by getListTerm() before the override is installed.');
+
+    $GLOBALS['config']['testmode.settings']['list_term'] = FALSE;
+    \Drupal::configFactory()->reset('testmode.settings');
+
+    $this->assertFalse($testmode->getListTerm(), 'getListTerm() returns the overridden value once $config[testmode.settings][list_term] is set.');
+  }
+
+}


### PR DESCRIPTION
Closes #46

## Summary

`Testmode::__construct()` cached a single editable `Config` object
obtained via `ConfigFactoryInterface::getEditable('testmode.settings')`
and every getter read from that instance. `ConfigFactory::getEditable()`
is documented to bypass the config override layer — it returns a mutable
`Config` meant for form save handlers, not for values read at query time.

As a result, any project that configured testmode via
`$config['testmode.settings'][…]` in `settings.php` — the standard
Drupal pattern for environment-specific dev/test configuration — had
the override silently ignored. `testmode_views_query_alter()` then used
the raw stored values and the intended filtering did not happen.

This change stores the `ConfigFactoryInterface` itself in the singleton
and splits reads from writes: reads go through `get()` (returns an
`ImmutableConfig` that applies overrides), writes still go through
`getEditable()` so form save handlers continue to round-trip correctly.
All public method signatures and behavior are preserved.

## Changes

### `src/Testmode.php`

- Replaced the cached `Config $config` property with
  `ConfigFactoryInterface $configFactory`.
- `__construct()` now stores the factory instead of calling
  `getEditable()` eagerly.
- Every getter (`getNodeViews()`, `getTermViews()`, `getUserViews()`,
  `getNodePatterns()`, `getTermPatterns()`, `getUserPatterns()`,
  `getListTerm()`) now calls
  `$this->configFactory->get('testmode.settings')->get(...)`, which
  returns the override-aware `ImmutableConfig`.
- Every setter (`setNodeViews()`, `setTermViews()`, `setUserViews()`,
  `setNodePatterns()`, `setTermPatterns()`, `setUserPatterns()`,
  `setTermsList()`) now calls
  `$this->configFactory->getEditable('testmode.settings')->set(...)->save()`,
  preserving the existing write semantics for form save handlers.

### `tests/src/Kernel/TestmodeConfigOverrideTest.php` (new)

- New kernel test that installs the `testmode` module's default config,
  writes a stored value through each setter, then installs an
  override via `$GLOBALS['config']['testmode.settings'][…]` and asserts
  that the matching getter returns the overridden value.
- Covers `views_node`, `views_term`, `views_user`, `pattern_node`,
  `pattern_term`, `pattern_user` via a data provider, and adds a
  dedicated test for `list_term`.
- The test is written test-first: it fails on unpatched code (the pre-
  override sanity assertion passes, the post-override assertion fails),
  then passes once the read path is routed through `ConfigFactory::get()`.

## Before / After

```
Before                                   After
──────                                   ─────

┌──────────────────────┐                 ┌──────────────────────────┐
│ Testmode singleton   │                 │ Testmode singleton       │
│  ├─ Config (editable)│  <-- cached     │  └─ ConfigFactoryInterface│
│  │   raw stored      │     once in     │                          │
│  │   values only     │     __construct │                          │
└──────────┬───────────┘                 └────────┬─────────────────┘
           │                                      │
           ▼                                      ▼
 getNodeViews() etc.                    getNodeViews() etc.
 → $this->config->get()                 → $configFactory->get(...)
 (bypasses overrides)                      ->get(...)
                                        (ImmutableConfig, applies
                                         $config[...] overrides)

 setNodeViews() etc.                    setNodeViews() etc.
 → $this->config->set()->save()         → $configFactory->getEditable(...)
                                          ->set(...)->save()
                                        (explicit getEditable for writes)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes Testmode to properly respect configuration overrides from settings.php by refactoring how configuration is accessed at runtime.

## Changes

### Updated src/Testmode.php
- Use ConfigFactoryInterface instead of caching a Config instance:
  - Protected property changed from `Config $config` to `ConfigFactoryInterface $configFactory`.
  - Constructor stores the factory instead of calling `getEditable()` eagerly.
  - All getters (`getNodeViews`, `getTermViews`, `getUserViews`, `getNodePatterns`, `getTermPatterns`, `getUserPatterns`, `getListTerm`) now read via `$this->configFactory->get('testmode.settings')->get(...)` so overrides from settings.php are applied.
  - All setters (`setNodeViews`, `setTermViews`, `setUserViews`, `setNodePatterns`, `setTermPatterns`, `setUserPatterns`, `setTermsList`) continue to use `$this->configFactory->getEditable('testmode.settings')->set(...)->save()` to preserve form-save write semantics.
- Public method signatures and behaviors are preserved.

### Added tests/src/Kernel/TestmodeConfigOverrideTest.php
- New kernel test class that verifies getters respect `$GLOBALS['config']` overrides (as provided via settings.php).
- Parameterized test `testGetterReflectsOverride()` covers `views_node`, `views_term`, `views_user`, `pattern_node`, `pattern_term`, `pattern_user`, and `list_term`.
- Tests write stored values via setters, apply a global override, reset the config factory cache, and assert getters return the overridden values.
- tearDown cleans global config overrides and resets config cache to avoid cross-test state leakage.
- Minor tidy: cleaned up global config override handling in test tearDown.

## Rationale

Previously, Testmode cached an editable Config obtained via `getEditable()`, which bypasses the override layer and caused settings.php overrides to be ignored. The fix separates reads (immutable config via `get()`, which applies overrides) from writes (`getEditable()`), restoring expected behavior while preserving form-save semantics.

## Related Issues

Closes #46
<!-- end of auto-generated comment: release notes by coderabbit.ai -->